### PR TITLE
Repository migration release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.1 - 2022-09-02
+### Changed
+- The crate has migrated to a new repository ([#1])
+
+[#1]: https://github.com/newpavlov/rosbag-rs/pull/1
+
 ## 0.6.0 - 2022-05-25
 ### Added
 - `message_definition` field to connection header ([#8])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosbag"
-version = "0.6.0" # Also update html_root_url in lib.rs when bumping this
+version = "0.6.1"
 description = "Utilities for reading ROS bag files."
 authors = ["Artyom Pavlov <newpavlov@gmail.com>"]
 license = "MIT OR Apache-2.0"
@@ -8,7 +8,7 @@ edition = "2021"
 rust-version = "1.56"
 readme = "README.md"
 documentation = "https://docs.rs/rosbag"
-repository = "https://github.com/SkoltechRobotics/rosbag-rs"
+repository = "https://github.com/newpavlov/rosbag-rs"
 keywords = ["ros", "datasets", "robotics"]
 categories = ["parser-implementations", "science::robotics"]
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ additional terms or conditions.
 [docs-link]: https://docs.rs/rosbag
 [rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[build-image]: https://github.com/SkoltechRobotics/rosbag-rs/actions/workflows/rosbag.yml/badge.svg
-[build-link]: https://github.com/SkoltechRobotics/rosbag-rs/actions/workflows/rosbag.yml
-[deps-image]: https://deps.rs/repo/github/SkoltechRobotics/rosbag-rs/status.svg
-[deps-link]: https://deps.rs/repo/github/SkoltechRobotics/rosbag-rs
+[build-image]: https://github.com/newpavlov/rosbag-rs/actions/workflows/rosbag.yml/badge.svg
+[build-link]: https://github.com/newpavlov/rosbag-rs/actions/workflows/rosbag.yml
+[deps-image]: https://deps.rs/repo/github/newpavlov/rosbag-rs/status.svg
+[deps-link]: https://deps.rs/repo/github/newpavlov/rosbag-rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@
 //! }
 //! # Ok(()) }
 //! ```
-#![doc(html_root_url = "https://docs.rs/rosbag/0.5.0")]
 #![warn(missing_docs, rust_2018_idioms)]
 
 use memmap2::Mmap;


### PR DESCRIPTION
The previously used organization was blocked due to the U.S. sanctions on the Skoltech University.