### PR TITLE
Allow missing latching field in connection

### DIFF
--- a/src/record_types/connection.rs
+++ b/src/record_types/connection.rs
@@ -73,7 +73,7 @@ impl<'a> RecordGen<'a> for Connection<'a> {
                 "latching" => {
                     latching = match val {
                         b"1" => true,
-                        b"0" => false,
+                        b"0" | b"" => false,
                         _ => return Err(Error::InvalidRecord),
                     }
                 }


### PR DESCRIPTION
Hello! I've come across some bags that have an empty latching field, and these should fallback to `false` rather than failing.