### PR TITLE
Topic missing on connection's header generate error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.6.3 - 2024-05-27
+### Changed
+- Accept connection records without `topic` field ([#6])
+
+[#6]: https://github.com/newpavlov/rosbag-rs/pull/6
+
 ## 0.6.2 - 2024-05-22
 ### Changed
 - Accept empty `latching` field in connection headers ([#5])

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rosbag"
-version = "0.6.2"
+version = "0.6.3"
 description = "Utilities for reading ROS bag files."
 authors = ["Artyom Pavlov <newpavlov@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/src/record_types/connection.rs
+++ b/src/record_types/connection.rs
@@ -85,7 +85,7 @@ impl<'a> RecordGen<'a> for Connection<'a> {
             }
         }
 
-        let topic = topic.ok_or(Error::InvalidHeader)?;
+        let topic = topic.unwrap_or(storage_topic);
         let tp = tp.ok_or(Error::InvalidHeader)?;
         let md5sum = md5sum.ok_or(Error::InvalidHeader)?;
         let message_definition = message_definition.ok_or(Error::InvalidHeader)?;


### PR DESCRIPTION
On ROS Noetic rosbags, the header `topic` is missing in connection's headers.

I don't know if it's related to https://answers.ros.org/question/266967/why-does-rosbag_storage-add-topic-to-the-connection-header/ but this MR seems to fix the problem.

Note that in this library, the header is get from the record and not the connection's headers :

https://github.com/swri-robotics/bag-reader-java/blob/master/src/main/java/com/github/swrirobotics/bags/reader/records/Connection.java#L54C9-L54C16


